### PR TITLE
#13 [CT-1] 카테고리 개수 컴포넌트의 숫자값 중앙 고정

### DIFF
--- a/app/src/main/res/layout/item_category.xml
+++ b/app/src/main/res/layout/item_category.xml
@@ -24,17 +24,17 @@
 
     <ImageView
         android:id="@+id/imageCount"
-        android:layout_width="40dp"
+        android:layout_width="45dp"
         android:layout_height="30dp"
         android:layout_marginTop="15dp"
         android:layout_marginEnd="12dp"
         android:layout_marginBottom="15dp"
         android:background="@drawable/bg_button"
         android:backgroundTint="#F5F9F3"
+        android:importantForAccessibility="no"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        android:importantForAccessibility="no" />
+        app:layout_constraintTop_toTopOf="parent" />
 
     <TextView
         android:id="@+id/textCategoryCount"

--- a/app/src/main/res/layout/item_category.xml
+++ b/app/src/main/res/layout/item_category.xml
@@ -38,17 +38,16 @@
 
     <TextView
         android:id="@+id/textCategoryCount"
-        android:layout_width="19dp"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="15dp"
-        android:layout_marginEnd="22dp"
-        android:layout_marginBottom="15dp"
+        android:layout_width="wrap_content"
+        android:layout_height="22dp"
         android:gravity="center"
-        android:text="99"
+        android:includeFontPadding="false"
+        android:text="9999"
         android:textSize="15sp"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="@id/imageCount"
+        app:layout_constraintEnd_toEndOf="@id/imageCount"
+        app:layout_constraintStart_toStartOf="@id/imageCount"
+        app:layout_constraintTop_toTopOf="@id/imageCount"
         tools:ignore="HardcodedText" />
 
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 코드 리팩토링 or 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
- #13 

<br>  

## 📌 개요
- `count`의 출력 버그 fix

<br>  

## 🔁 변경 사항
> 기존) 숫자값의 크기 고정으로 `150`이 `15\n0`으로 출력됨
> 변경) 숫자값 중앙 고정
  
<br>  

## 📸 구현 화면 스크린샷
<img width="90" alt="category_count_1" src="https://github.com/HyunjeLee/Scrap-2024/assets/101737272/2dc16538-4a20-4dd0-8321-cf010541f42d">  
<img width="90" alt="category_count_150" src="https://github.com/HyunjeLee/Scrap-2024/assets/101737272/fa1ba40b-4f72-49d9-b458-e6e534b979ed"> 
<img width="90" alt="category_count_9999" src="https://github.com/HyunjeLee/Scrap-2024/assets/101737272/8234da76-07ed-454b-bfdd-87cce2aa9028">

<br>  

## 👀 기타 더 이야기해볼 점
- 다른 카테고리들과의 디자인 일관성을 위해 배경 크기를 숫자값에 따라 변경하지 않고 고정하고
숫자값을 중앙에 고정하는 방식으로 구현했습니다.  
<br>  

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
- [x] 담당자를 할당했어요.
- [x] 리뷰어를 할당했어요.
- [ ] ✨일요일 20:00 까지 모든 리뷰에 대해 
1. 해결하거나
2. 따로 이슈로 빼두고 노션에 공지했어요. (이슈 해결기간 제외)
- [x] android:exported 속성 확인
